### PR TITLE
Dev

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "standard"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /info.txt
 /tempCodeRunnerFile.py
 /workspace.code-workspace
+/node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,9 @@
-<<<<<<< HEAD
 {
-	"python.pythonPath": "C:\\Users\\alexw\\AppData\\Local\\Programs\\Python\\Python37-32\\python.exe"
-=======
-{
-	"python.pythonPath": "C:\\Users\\Alex\\AppData\\Local\\Programs\\Python\\Python37-32\\python.exe"
->>>>>>> test
+	"python.pythonPath": "C:\\Users\\alexw\\AppData\\Local\\Programs\\Python\\Python37-32\\python.exe",
+	"editor.tabSize": 2,
+	"prettier.tabWidth": 2,
+	"javascript.format.enable": false,
+	"prettier.eslintIntegration": true,
+	"prettier.printWidth": 120,
+	"prettier.singleQuote": true
 }

--- a/js/load.js
+++ b/js/load.js
@@ -9,33 +9,37 @@
 function getDownloads() {
   let pdfList = []
   chrome.downloads.search({
-      urlRegex: '/.+\.([pP][dD][fF])/g', // regex for .pdf files
+      finalUrlRegex: '.+\.pdf$', // regex for .pdf files
       limit: 500,
       orderBy: ['-startTime']
     },
     (data) => {
-      data.forEach(function (page) {
-
-        if((page.url).endsWith('.pdf')) {
-          console.error('Pushed file to list which does not end in \'.pdf\'')
-          console.groupCollapsed('url')
-          console.error(`url: ${page.url}`)
-          console.groupEnd()
-        }
+      data.forEach((page) => {
 
         if (!pdfList.includes(page)) { // check if page already in list
 
           pdfList.push(page) // add it to the array list
 
-          if (page.finalUrl != page.url) {
-            console.info(`[INFO] url and final url do not match`)
-            console.info(` > url: ${page.url}, finalUrl: ${page.finalUrl}`)
+          if (!(page.url).search('.pdf')) {
+            console.error('Pushed file to list which does not end in \'.pdf\'')
+            console.groupCollapsed('url')
+            console.error(`url: ${page.url}`)
+            console.groupEnd()
           }
 
         } else {
           console.info(`Duplicate file not pushed to file list.`)
           console.groupCollapsed('url')
           console.info(page.url)
+          console.groupEnd()
+        }
+      })
+      console.info(`${pdfList.length} PDF files found.`)
+
+      pdfList.forEach((page) => {
+        if (page.finalUrl != page.url) {
+          console.groupCollapsed(`page.url does not match page.finaUrl.`)
+          console.info(`url: ${page.url}\nfinalUrl: ${page.finalUrl}`)
           console.groupEnd()
         }
       })

--- a/js/load.js
+++ b/js/load.js
@@ -7,25 +7,37 @@
  */
 
 function getDownloads() {
-	let pdfList = []
-	chrome.downloads.search({
-			urlRegex: '.+\.([pP][dD][fF])', // regex for .pdf files
-			limit: 500,
-			orderBy: ['-startTime']
-		},
-		(data) => {
-			data.forEach(function (page) {
-				if (!pdfList.includes(page)) { // check if page already in list
-					
-					pdfList.push(page) // add it to the array list
+  let pdfList = []
+  chrome.downloads.search({
+      urlRegex: '/.+\.([pP][dD][fF])/g', // regex for .pdf files
+      limit: 500,
+      orderBy: ['-startTime']
+    },
+    (data) => {
+      data.forEach(function (page) {
 
-					if (page.finalUrl != page.url) {
-						console.log(`[INFO] url and final url do not match`)
-						console.log(` > url: ${page.url}, finalUrl: ${page.finalUrl}`)
-					}
-				} else {
-					console.info(`Duplicate file not pushed to file list.`);
-				}
-			})
-		})
+        if((page.url).endsWith('.pdf')) {
+          console.error('Pushed file to list which does not end in \'.pdf\'')
+          console.groupCollapsed('url')
+          console.error(`url: ${page.url}`)
+          console.groupEnd()
+        }
+
+        if (!pdfList.includes(page)) { // check if page already in list
+
+          pdfList.push(page) // add it to the array list
+
+          if (page.finalUrl != page.url) {
+            console.info(`[INFO] url and final url do not match`)
+            console.info(` > url: ${page.url}, finalUrl: ${page.finalUrl}`)
+          }
+
+        } else {
+          console.info(`Duplicate file not pushed to file list.`)
+          console.groupCollapsed('url')
+          console.info(page.url)
+          console.groupEnd()
+        }
+      })
+    })
 }

--- a/js/script.js
+++ b/js/script.js
@@ -162,7 +162,6 @@ function searchDownloads() {
         //console.log(`[INFO] ${localPdfCount} local PDFs found.`)
 
         loadSettings()
-        footer(2)
     })
 }
 
@@ -172,27 +171,22 @@ function footer(count) {
     let footerDivs = document.getElementsByClassName('footer')
     let footerLeft = document.getElementById('footer-left')
 
-    let countDisplay = document.createElement('p')
-    countDisplay.id = 'count-display'
-    countDisplay.innerHTML = 'placeholder for count display'
+    let countDisplay = document.getElementById('count-display')
 
-    footerLeft.appendChild(countDisplay)
+    countDisplay.innerHTML = `Found ${count} online PDF files.`
 
-    let settingsIcon
-    for (e of footerDivs) {
-        console.log(e)
-    }
 }
 
-function localFooter() {
-    let plural = (localPdfCount > 1 ? 's' : '')
+function localFooter(count) {
+    let plural = (count > 1 ? 's' : '')
 
-    let localFooter = document.createElement('p')
-    localFooter.innerHTML =
-        `Showing ${localPdfCount} locally saved PDF${plural}.`
-    localFooter.classList.add('footer')
-    localFooter.id = 'local-footer'
-    fileElement.appendChild(localFooter)
+    let footerDivs = document.getElementsByClassName('footer')
+    let footerLeft = document.getElementById('footer-left')
+
+    let countDisplay = document.getElementById('count-display')
+
+    countDisplay.innerHTML = `Found ${count} local PDF files.`
+
 }
 
 // tab buttons
@@ -203,10 +197,12 @@ let settingsTabLink = document.getElementById('settings-link')
 // event handlers for tab buttons
 onlineTabLink.addEventListener('click',
     function () {
+        footer(onlineCount)
         openTab(event, 'online')
     })
 
 localTabLink.addEventListener('click', function () {
+    localFooter(localPdfCount)
     openTab(event, 'local')
 })
 
@@ -217,6 +213,7 @@ settingsTabLink.addEventListener(
     })
 
 onlineTabLink.click()
+footer(onlineCount)
 
 // function that handles switching between tabs
 function openTab(evt, tabName) {

--- a/js/script.js
+++ b/js/script.js
@@ -28,164 +28,164 @@ maxLocalFilesPerPage = 30
 searchHistory()
 
 function searchHistory() {
-    chrome.history.search({
-        text: '.pdf',
-        maxResults: 10000
-    }, function (data) {
+  chrome.history.search({
+    text: '.pdf',
+    maxResults: 10000
+  }, function (data) {
 
-        data.forEach(function (page) {
+    data.forEach(function (page) {
 
-            if (page.url.endsWith('.pdf')) { // check if page is a .pdf
+      if (page.url.endsWith('.pdf')) { // check if page is a .pdf
 
-                let listItem = document.createElement('li')
-                listItem.classList.add('list-item')
+        let listItem = document.createElement('li')
+        listItem.classList.add('list-item')
 
-                if (!page.url.startsWith('file:')) {
-                    onlineCount++
+        if (!page.url.startsWith('file:')) {
+          onlineCount++
 
-                    let leftDiv = document.createElement('div')
-                    let rightDiv = document.createElement('div')
-                    leftDiv.classList.add('list-div', 'left')
-                    rightDiv.classList.add('list-div', 'right')
+          let leftDiv = document.createElement('div')
+          let rightDiv = document.createElement('div')
+          leftDiv.classList.add('list-div', 'left')
+          rightDiv.classList.add('list-div', 'right')
 
-                    let title = document.createElement('p')
-                    title.classList.add('link-title')
-                    title.innerText = decodeURI(page.url).substring(
-                        page.url.lastIndexOf('/') + 1, page.url.length - 4)
+          let title = document.createElement('p')
+          title.classList.add('link-title')
+          title.innerText = decodeURI(page.url).substring(
+            page.url.lastIndexOf('/') + 1, page.url.length - 4)
 
-                    let linkUrl = document.createElement('p')
-                    linkUrl.classList.add('link-url')
-                    linkUrl.innerHTML =
-                        decodeURI(page.url).substring(0, 50).replace(' ', '')
+          let linkUrl = document.createElement('p')
+          linkUrl.classList.add('link-url')
+          linkUrl.innerHTML =
+            decodeURI(page.url).substring(0, 50).replace(' ', '')
 
-                    let icon = document.createElement('img')
-                    icon.classList.add('link-thumb')
-                    icon.src = `chrome://favicon/${page.url}`
+          let icon = document.createElement('img')
+          icon.classList.add('link-thumb')
+          icon.src = `chrome://favicon/${page.url}`
 
-                    leftDiv.appendChild(icon)
-                    leftDiv.appendChild(title)
-                    leftDiv.appendChild(document.createElement('br'))
-                    leftDiv.appendChild(linkUrl)
+          leftDiv.appendChild(icon)
+          leftDiv.appendChild(title)
+          leftDiv.appendChild(document.createElement('br'))
+          leftDiv.appendChild(linkUrl)
 
-                    leftDiv.addEventListener('click',
-                        function () {
-                            window.open(page.url)
-                        })
+          leftDiv.addEventListener('click',
+            function () {
+              window.open(page.url)
+            })
 
-                    listItem.appendChild(leftDiv)
-                    listItem.appendChild(rightDiv)
-                    onlineList.appendChild(listItem)
-                }
-            }
-        })
-
-        searchDownloads()
-        console.log(`${onlineCount} online PDFs found.`)
+          listItem.appendChild(leftDiv)
+          listItem.appendChild(rightDiv)
+          onlineList.appendChild(listItem)
+        }
+      }
     })
+
+    searchDownloads()
+    console.log(`${onlineCount} online PDFs found.`)
+  })
 }
 
 let localFiles = []
 
 function searchDownloads() {
-    chrome.downloads.search({
-        limit: 1000,
-        orderBy: ['-startTime']
-    }, function (
-        data) {
-        data.forEach(function (file, i) {
-            if (file.filename.endsWith('.pdf')) {
-                if (!localFiles.includes(file.filename) &&
-                    localPdfCount < 30) {
-                    localFiles.push(file.filename)
+  chrome.downloads.search({
+    limit: 1000,
+    orderBy: ['-startTime']
+  }, function (
+    data) {
+    data.forEach(function (file, i) {
+      if (file.filename.endsWith('.pdf')) {
+        if (!localFiles.includes(file.filename) &&
+          localPdfCount < 30) {
+          localFiles.push(file.filename)
 
 
-                    localPdfCount++
+          localPdfCount++
 
-                    let leftDiv = document.createElement('div')
-                    let rightDiv = document.createElement('div')
-                    leftDiv.classList.add('list-div', 'left')
-                    rightDiv.classList.add('list-div', 'right')
+          let leftDiv = document.createElement('div')
+          let rightDiv = document.createElement('div')
+          leftDiv.classList.add('list-div', 'left')
+          rightDiv.classList.add('list-div', 'right')
 
-                    let fileItem = document.createElement('li')
-                    fileItem.classList.add('list-item', 'file-item')
+          let fileItem = document.createElement('li')
+          fileItem.classList.add('list-item', 'file-item')
 
-                    let icon = document.createElement('img')
-                    icon.classList.add('link-thumb')
-                    chrome.downloads.getFileIcon(
-                        file.id, {
-                            size: 16
-                        },
-                        function (iconUrl) {
-                            icon.src = iconUrl
-                        })
+          let icon = document.createElement('img')
+          icon.classList.add('link-thumb')
+          chrome.downloads.getFileIcon(
+            file.id, {
+              size: 16
+            },
+            function (iconUrl) {
+              icon.src = iconUrl
+            })
 
-                    let title = document.createElement('p')
-                    title.classList.add('link-title')
-                    title.innerText = file.filename.substring(
-                        file.filename.lastIndexOf('\\') + 1, file.filename.length - 4)
+          let title = document.createElement('p')
+          title.classList.add('link-title')
+          title.innerText = file.filename.substring(
+            file.filename.lastIndexOf('\\') + 1, file.filename.length - 4)
 
-                    let linkUrl = document.createElement('p')
-                    linkUrl.classList.add('link-url')
-                    linkUrl.innerHTML =
-                        file.filename.substring(0, file.filename.lastIndexOf('\\') + 1)
+          let linkUrl = document.createElement('p')
+          linkUrl.classList.add('link-url')
+          linkUrl.innerHTML =
+            file.filename.substring(0, file.filename.lastIndexOf('\\') + 1)
 
-                    leftDiv.appendChild(icon)
-                    leftDiv.appendChild(title)
-                    leftDiv.appendChild(document.createElement('br'))
-                    leftDiv.appendChild(linkUrl)
+          leftDiv.appendChild(icon)
+          leftDiv.appendChild(title)
+          leftDiv.appendChild(document.createElement('br'))
+          leftDiv.appendChild(linkUrl)
 
-                    leftDiv.addEventListener(
-                        'click',
-                        function () {
-                            chrome.downloads.open(file.id)
-                        })
+          leftDiv.addEventListener(
+            'click',
+            function () {
+              chrome.downloads.open(file.id)
+            })
 
-                    let more = document.createElement('img')
-                    more.id = 'more_icon'
-                    more.src = '../../assets/More.png'
-                    more.addEventListener('click',
-                        function () {
-                            chrome.downloads.show(file.id)
-                        })
+          let more = document.createElement('img')
+          more.id = 'more_icon'
+          more.src = '../../assets/More.png'
+          more.addEventListener('click',
+            function () {
+              chrome.downloads.show(file.id)
+            })
 
-                    rightDiv.appendChild(more)
+          rightDiv.appendChild(more)
 
-                    fileItem.appendChild(leftDiv)
-                    fileItem.appendChild(rightDiv)
-                    fileElement.appendChild(fileItem)
-                } else {
-                    //console.log(`[INFO] skipped duplicate file: ${file.filename}.`)
-                }
-            }
-        })
-
-        //console.log(`[INFO] ${localPdfCount} local PDFs found.`)
-
-        loadSettings()
+          fileItem.appendChild(leftDiv)
+          fileItem.appendChild(rightDiv)
+          fileElement.appendChild(fileItem)
+        } else {
+          //console.log(`[INFO] skipped duplicate file: ${file.filename}.`)
+        }
+      }
     })
+
+    //console.log(`[INFO] ${localPdfCount} local PDFs found.`)
+
+    loadSettings()
+  })
 }
 
 function footer(count) {
-    let plural = (count > 1 ? 's' : '')
+  let plural = (count > 1 ? 's' : '')
 
-    let footerDivs = document.getElementsByClassName('footer')
-    let footerLeft = document.getElementById('footer-left')
+  let footerDivs = document.getElementsByClassName('footer')
+  let footerLeft = document.getElementById('footer-left')
 
-    let countDisplay = document.getElementById('count-display')
+  let countDisplay = document.getElementById('count-display')
 
-    countDisplay.innerHTML = `Found ${count} online PDF files.`
+  countDisplay.innerHTML = `Found ${count} online PDF files.`
 
 }
 
 function localFooter(count) {
-    let plural = (count > 1 ? 's' : '')
+  let plural = (count > 1 ? 's' : '')
 
-    let footerDivs = document.getElementsByClassName('footer')
-    let footerLeft = document.getElementById('footer-left')
+  let footerDivs = document.getElementsByClassName('footer')
+  let footerLeft = document.getElementById('footer-left')
 
-    let countDisplay = document.getElementById('count-display')
+  let countDisplay = document.getElementById('count-display')
 
-    countDisplay.innerHTML = `Found ${count} local PDF files.`
+  countDisplay.innerHTML = `Found ${count} local PDF files.`
 
 }
 
@@ -196,50 +196,50 @@ let settingsTabLink = document.getElementById('settings-link')
 
 // event handlers for tab buttons
 onlineTabLink.addEventListener('click',
-    function () {
-        footer(onlineCount)
-        openTab(event, 'online')
-    })
+  function () {
+    footer(onlineCount)
+    openTab(event, 'online')
+  })
 
 localTabLink.addEventListener('click', function () {
-    localFooter(localPdfCount)
-    openTab(event, 'local')
+  localFooter(localPdfCount)
+  openTab(event, 'local')
 })
 
 settingsTabLink.addEventListener(
-    'click',
-    function () {
-        open('../options/options.html')
-    })
+  'click',
+  function () {
+    open('../options/options.html')
+  })
 
 onlineTabLink.click()
 footer(onlineCount)
 
 // function that handles switching between tabs
 function openTab(evt, tabName) {
-    var i, tabcontent, tablinks
-    tabcontent = document.getElementsByClassName('tabcontent')
-    for (i = 0; i < tabcontent.length; i++) {
-        tabcontent[i].style.display = 'none'
-    }
-    tablinks = document.getElementsByClassName('tablinks')
-    for (i = 0; i < tablinks.length; i++) {
-        tablinks[i].className = tablinks[i].className.replace(' active', '')
-    }
-    document.getElementById(tabName).style.display = 'inline-block'
-    evt.currentTarget.className += ' active'
+  var i, tabcontent, tablinks
+  tabcontent = document.getElementsByClassName('tabcontent')
+  for (i = 0; i < tabcontent.length; i++) {
+    tabcontent[i].style.display = 'none'
+  }
+  tablinks = document.getElementsByClassName('tablinks')
+  for (i = 0; i < tablinks.length; i++) {
+    tablinks[i].className = tablinks[i].className.replace(' active', '')
+  }
+  document.getElementById(tabName).style.display = 'inline-block'
+  evt.currentTarget.className += ' active'
 }
 
 // function that loads the settings from the options.js script
 function loadSettings() {
-    chrome.storage.sync.get(['savedTab', 'filesPerPage'], function (result) {
-        console.log(result)
-        if (result.savedTab) {
-            document.getElementById('online-footer').style = 'color: red'
-        }
+  chrome.storage.sync.get(['savedTab', 'filesPerPage'], function (result) {
+    console.log(result)
+    if (result.savedTab) {
+      document.getElementById('online-footer').style = 'color: red'
+    }
 
-        if (result.filesPerPage) {
-            maxLocalFilesPerPage = result.filesPerPage
-        }
-    })
+    if (result.filesPerPage) {
+      maxLocalFilesPerPage = result.filesPerPage
+    }
+  })
 }

--- a/js/script.js
+++ b/js/script.js
@@ -23,6 +23,8 @@ let maxLocalFilesPerPage = 11 // setting set to 11 by default
 // load the user settings
 loadSettings()
 
+maxLocalFilesPerPage = 30
+
 searchHistory()
 
 function searchHistory() {
@@ -93,7 +95,7 @@ function searchDownloads() {
         data.forEach(function (file, i) {
             if (file.filename.endsWith('.pdf')) {
                 if (!localFiles.includes(file.filename) &&
-                    localPdfCount < maxLocalFilesPerPage) {
+                    localPdfCount < 30) {
                     localFiles.push(file.filename)
 
 

--- a/js/script.js
+++ b/js/script.js
@@ -7,7 +7,7 @@
  *  last modified: 9/24/2018
  */
 
- getDownloads()
+getDownloads()
 
 let localPdfCount = 0
 let onlineCount = 0

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "recent-pdf",
+  "version": "1.0.0",
+  "description": "A Chrome extension.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexweininger/recent-pdfs.git"
+  },
+  "author": "Alex Weininger",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/alexweininger/recent-pdfs/issues"
+  },
+  "homepage": "https://github.com/alexweininger/recent-pdfs#readme",
+  "devDependencies": {
+    "eslint": "^5.6.1",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0"
+  }
+}

--- a/src/browser_action/index.html
+++ b/src/browser_action/index.html
@@ -37,7 +37,9 @@
   </div>
 
   <div class="footer">
-    <div class="" id="footer-left"></div>
+    <div class="" id="footer-left">
+      <p id="count-display"></p>
+    </div>
     <div class="" id="footer-right">
       <button id="settings-link" class="">
         <img src="../../assets/settings_icon.jpeg" id="settings-icon">

--- a/src/browser_action/index.html
+++ b/src/browser_action/index.html
@@ -149,7 +149,6 @@
     height: -moz-fit-content;
     height: -webkit-fit-content;
     height: auto;
-    min-height: 15%;
   }
 
   #link-list,

--- a/src/browser_action/index.html
+++ b/src/browser_action/index.html
@@ -50,21 +50,26 @@
 
 <style>
   html {
-    height: fit-content;
+    height: 436px;
     margin: 0 0 0 0;
+    padding-bottom: 2px;
     padding: 0;
     max-width: 400px;
-    overflow:unset;
+    max-height: 436px;
+    overflow: hidden;
   }
 
   body {
-    font-family: sans-serif;
-    height: inherit;
     margin: 0 0 0 0;
-    min-width: 300px;
-    width: 400px;
+    font-family: sans-serif;
     color: black;
-    max-width: 400px;
+    width: 100%;
+    max-height: 100%;
+    /* overflow-y: scroll;
+    padding-right: 21px; 
+    box-sizing: content-box;
+    overflow-x: hidden; */
+    overflow: hidden;
   }
 
   #more_icon {
@@ -129,16 +134,20 @@
   }
 
   .tabcontent {
-    border: none;
-    display: none;
-    max-width: 400px;
-    min-height: fit-content;
-    padding: 0;
+    padding: 0 0 0 0;
+    width: 100%;
+    resize: none;
+    max-height: 384px;
+    overflow-y: scroll;
+    padding-right: 21px; /* Increase/decrease this value for cross-browser compatibility */
+    box-sizing: content-box; /* So the width will be 100% + 17px */
+    overflow-x: hidden;
+    display: inline-block;
+    font-size: 14px;
+    height: -moz-fit-content;
+    height: -webkit-fit-content;
     height: auto;
-  }
-
-  .tabcontent-container {
-    min-height: auto;
+    min-height: 15%;
   }
 
   #link-list,
@@ -151,16 +160,6 @@
     min-width: 180px;
     padding: 0px 0px 0px 0px;
     width: 100%;
-  }
-
-  .tabcontent {
-    display: inline-block;
-    font-size: 14px;
-    height: -moz-fit-content;
-    height: -webkit-fit-content;
-    height: auto;
-    min-height: 15%;
-    width: 400px;
   }
 
   .list-item {
@@ -217,12 +216,13 @@
     height: 20px;
     display: grid;
     grid-template-columns: 94% 6%;
+    background: white;
   }
 
   .footer div {
     height: 16px;
-    margin: 3 0 0 0;
-    padding: 0;
+    margin: 0 0 0 0;
+    padding: 2 0 2 0;
   }
 
   #settings-link {
@@ -245,10 +245,6 @@
     margin: 0 0 0 3px;
   }
 
-  .dark {
-    color: #eee;
-    background: #333;
-  }
 </style>
 <script src="../../js/load.js"></script>
 <script src="../../js/script.js"></script>


### PR DESCRIPTION
Displaying more than 10 pdf files now is handled dynamically.

![image](https://user-images.githubusercontent.com/12476526/46443466-922c6a80-c722-11e8-8bf5-01fa4afb4ca2.png)

The loading of the pdf files and the display logic is now separated into two js files.  Load.js and Script.js.

Stopped using endsWith() on the url, started using the search for mathing regex function provided by the Chrome API [here](https://developer.chrome.com/extensions/downloads#method-search).

Added eslint standard to the repo

And the file counter now works for both local and online files.