### PR TITLE
Added "No PDFs found"

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -59,6 +59,9 @@ function searchHistory () {
         }
       }
     })
+    if(onlineCount > 0) {
+      document.getElementById("noOnline").remove();
+    }
     footer(onlineCount)
     searchDownloads()
     console.log(`${onlineCount} online PDFs found.`)
@@ -138,6 +141,9 @@ function searchDownloads () {
       }
     })
 
+    if(localPdfCount > 0) {
+      document.getElementById("noLocal").remove();
+    }
     // console.log(`[INFO] ${localPdfCount} local PDFs found.`)
 
     loadSettings()

--- a/src/browser_action/index.html
+++ b/src/browser_action/index.html
@@ -16,6 +16,9 @@
     <div id="online" class="tabcontent">
       <div id="link-div">
         <ul id="link-list">
+          <li id="noOnline">
+            <div class="nothingHere">No Online PDFs found :(</div>
+          </li>
         </ul>
       </div>
     </div>
@@ -23,6 +26,9 @@
     <div id="local" class="tabcontent">
       <div id="local-div">
         <ul id="file-list">
+          <li id="noLocal">
+            <div class="nothingHere">No Local PDFs found :(</div>
+          </li>
         </ul>
       </div>
     </div>

--- a/src/browser_action/style.css
+++ b/src/browser_action/style.css
@@ -219,3 +219,14 @@ li {
 	height: inherit;
 	margin: 0 0 0 3px;
 }
+
+
+.nothingHere {
+	display:inline-block;
+	width: 100%;
+	text-align:center;
+	padding-top: 50px;
+	text-transform: uppercase;
+	letter-spacing: 2px;
+	font-family: "Helvetica";
+}


### PR DESCRIPTION
Added a message that will be displayed if no PDF's were found.  The message is a simple default li tag containing a div that will be removed if the count is greater than 0.

I think a search field will be a nice feature at some point.  If it's added, it may be better to make the visibility hidden rather tan remove.  That way, it can be made visible if the search yields no results.

### Fixes issue #
There is no issue for this - I was just kind of playing around with this.  If you don't like the changes, please throw them out.  I will make comments in the future about things and if you like the idea and there is a general issue open, I will commit to that.

## Screenshots
![nothingfound](https://user-images.githubusercontent.com/6131198/46891585-56875400-ce38-11e8-9291-1aa863fd4986.png)


### before PR

### after PR

## Proposed Changes

-  
-  
-  

If your current branch is `master`, you should choose to create a new branch for your commit and then create a [pull request](https://help.github.com/articles/creating-a-pull-request).
