### PR TITLE
Adjust size of local pdf icon and change its position

### DIFF
--- a/src/browser_action/style.css
+++ b/src/browser_action/style.css
@@ -15,7 +15,7 @@ body {
 	width: 100%;
 	max-height: 100%;
 	/* overflow-y: scroll;
-	padding-right: 21px; 
+	padding-right: 21px;
 	box-sizing: content-box;
 	overflow-x: hidden; */
 	overflow: hidden;
@@ -102,11 +102,11 @@ div.left {
 .tabcontent::-webkit-scrollbar {
     width: 6px;
 }
- 
+
 .tabcontent::-webkit-scrollbar-track {
     -webkit-box-shadow: inset 0 0 4px rgba(0,0,0,0.3);
 }
- 
+
 .tabcontent::-webkit-scrollbar-thumb {
   background-color: darkgrey;
   outline: 1px solid slategrey;
@@ -140,9 +140,8 @@ div.left {
 }
 
 .link-thumb {
-	margin: 0 6px 0 4px;
-	height: 30px;
-	width: 30px;
+	margin: 4px 6px 0 4px;
+	width: 20px;
 	float: left;
 }
 


### PR DESCRIPTION
### Fixes issue #
https://github.com/alexweininger/recent-pdf/issues/34

## Screenshots
https://monosnap.com/file/n1qbdJqT1NCmFbXNCHrBT7FSVs6kHJ

### before PR

### after PR
Icon is smaller and its position is adjusted to the pdf name.

## Proposed Changes

-  
-  
-  

If your current branch is `master`, you should choose to create a new branch for your commit and then create a [pull request](https://help.github.com/articles/creating-a-pull-request).
